### PR TITLE
fix(usage): fix path for hourly endpoint

### DIFF
--- a/src/data/usage-api-v2.json
+++ b/src/data/usage-api-v2.json
@@ -102,7 +102,7 @@
         }
       }
     },
-    "/2/metrics/hourly/applications/:application": {
+    "/2/metrics/hourly": {
       "get": {
         "summary": "Returns a list of billing metrics per hour for the specified application",
         "operationId": "retrieveApplicationMetricsHourly",
@@ -251,10 +251,7 @@
       },
       "DailyEntry": {
         "type": "object",
-        "required": [
-          "date",
-          "values"
-        ],
+        "required": ["date", "values"],
         "properties": {
           "date": {
             "type": "string",
@@ -294,10 +291,7 @@
       },
       "HourlyEntry": {
         "type": "object",
-        "required": [
-          "date",
-          "values"
-        ],
+        "required": ["date", "values"],
         "properties": {
           "time": {
             "type": "string",


### PR DESCRIPTION
The endpoint for the hourly metrics was wrong, this fixes it in the spec.

Related: https://algolia.slack.com/archives/CT17NJBQF/p1745310179933829