### PR TITLE
feat(settings): attributes for faceting and custom ranking

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,9 @@ const DEFAULT_ALLOW_TOOLS = [
   "updateQuerySuggestionsConfig",
   "getQuerySuggestionConfigStatus",
   "getQuerySuggestionLogFile",
+  // Custom settings
+  "setAttributesForFaceting",
+  "setCustomRanking",
 ];
 const ALLOW_TOOLS_OPTIONS_TUPLE = [
   "-t, --allow-tools <tools>",

--- a/src/commands/start-server.ts
+++ b/src/commands/start-server.ts
@@ -5,12 +5,12 @@ import { authenticate } from "../authentication.ts";
 import { AppStateManager } from "../appState.ts";
 import { DashboardApi } from "../DashboardApi.ts";
 import {
-  registerGetUserInfo,
   operationId as GetUserInfoOperationId,
+  registerGetUserInfo,
 } from "../tools/registerGetUserInfo.ts";
 import {
-  registerGetApplications,
   operationId as GetApplicationsOperationId,
+  registerGetApplications,
 } from "../tools/registerGetApplications.ts";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerOpenApiTools } from "../tools/registerOpenApi.ts";
@@ -18,15 +18,23 @@ import { CONFIG } from "../config.ts";
 import {
   ABTestingSpec,
   AnalyticsSpec,
+  CollectionsSpec,
+  IngestionSpec,
   MonitoringSpec,
+  QuerySuggestionsSpec,
   RecommendSpec,
   SearchSpec,
-  IngestionSpec,
   UsageSpec,
-  CollectionsSpec,
-  QuerySuggestionsSpec,
 } from "../openApi.ts";
 import { type CliFilteringOptions, getToolFilter, isToolAllowed } from "../toolFilters.ts";
+import {
+  operationId as SetAttributesForFacetingOperationId,
+  registerSetAttributesForFaceting,
+} from "../tools/registerSetAttributesForFaceting.ts";
+import {
+  registerSetCustomRanking,
+  operationId as SetCustomRankingOperationId
+} from "../tools/registerSetCustomRanking.js";
 
 export type StartServerOptions = CliFilteringOptions;
 
@@ -165,7 +173,6 @@ export async function startServer(opts: StartServerOptions) {
     });
 
     // Collections API Tools
-
     registerOpenApiTools({
       server,
       dashboardApi,
@@ -174,13 +181,21 @@ export async function startServer(opts: StartServerOptions) {
     });
 
     // Query Suggestions API Tools
-
     registerOpenApiTools({
       server,
       dashboardApi,
       openApiSpec: QuerySuggestionsSpec,
       toolFilter,
     });
+
+    // Custom settings Tools
+    if (isToolAllowed(SetAttributesForFacetingOperationId, toolFilter)) {
+      registerSetAttributesForFaceting(server, dashboardApi);
+    }
+
+    if (isToolAllowed(SetCustomRankingOperationId, toolFilter)) {
+      registerSetCustomRanking(server, dashboardApi);
+    }
 
     const transport = new StdioServerTransport();
     await server.connect(transport);

--- a/src/commands/start-server.ts
+++ b/src/commands/start-server.ts
@@ -34,7 +34,7 @@ import {
 import {
   registerSetCustomRanking,
   operationId as SetCustomRankingOperationId
-} from "../tools/registerSetCustomRanking.js";
+} from "../tools/registerSetCustomRanking.ts";
 
 export type StartServerOptions = CliFilteringOptions;
 

--- a/src/tools/registerSetAttributesForFaceting.ts
+++ b/src/tools/registerSetAttributesForFaceting.ts
@@ -1,0 +1,57 @@
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { algoliasearch } from "algoliasearch";
+import { z } from "zod";
+import type { DashboardApi } from "../DashboardApi.ts";
+
+export const operationId = "setAttributesForFaceting";
+export const description =
+  "lets you create categories based on specific attributes so users can filter search results by those categories. For example, if you have an index of books, you could categorize them by author and genre. This allows users to filter search results by their favorite author or discover new genres. To enable this categorization, declare your attributes as `attributesForFaceting`";
+
+const attributesForFacetingSchema = {
+  applicationId: z.string().describe("The application ID that owns the index to manipulate"),
+  indexName: z
+    .string()
+    .describe("The index name on which you want to set the attributes for faceting"),
+  attributesForFaceting: z
+    .array(z.string())
+    .min(1)
+    .describe("The list of attributes on which you want to be able to apply category filters"),
+};
+
+export function registerSetAttributesForFaceting(server: McpServer, dashboardApi: DashboardApi) {
+  server.tool(
+    operationId,
+    description,
+    attributesForFacetingSchema,
+    async ({ applicationId, indexName, attributesForFaceting }) => {
+      const apiKey = await dashboardApi.getApiKey(applicationId);
+
+      const client = algoliasearch(applicationId, apiKey);
+
+      const task = await client.setSettings({
+        indexName,
+        indexSettings: {
+          attributesForFaceting,
+        },
+      });
+
+      await client.waitForTask({ indexName, taskID: task.taskID });
+
+      const currentSettings = await client.getSettings({
+        indexName,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              currentSettings.attributesForFaceting != null
+                ? `The current attributes for faceting are: ${currentSettings.attributesForFaceting.join(", ")}`
+                : "No attributes for faceting found.",
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/registerSetCustomRanking.ts
+++ b/src/tools/registerSetCustomRanking.ts
@@ -1,0 +1,68 @@
+import { type McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { algoliasearch } from "algoliasearch";
+import { z } from "zod";
+import type { DashboardApi } from "../DashboardApi.ts";
+
+export const operationId = "setCustomRanking";
+export const description =
+  "Set the custom ranking for an Algolia index. This allows you to define how the results are sorted based on the attributes you specify. You can use this to prioritize certain attributes over others when displaying search results.";
+
+const setCustomRankingSchema = {
+  applicationId: z.string().describe("The application ID that owns the index to manipulate"),
+  indexName: z
+    .string()
+    .describe("The index name on which you want to set the attributes for faceting"),
+  customRanking: z
+    .array(
+      z.object({
+        attribute: z.string().describe("The attribute name"),
+        direction: z
+          .enum(["asc", "desc"])
+          .optional()
+          .default("desc")
+          .describe("The direction of the ranking (can be either 'asc' or 'desc')"),
+      }),
+    )
+    .min(1)
+    .describe("The attributes you want to use for custom ranking"),
+};
+
+export function registerSetCustomRanking(server: McpServer, dashboardApi: DashboardApi) {
+  server.tool(
+    operationId,
+    description,
+    setCustomRankingSchema,
+    async ({ applicationId, indexName, customRanking }) => {
+      const apiKey = await dashboardApi.getApiKey(applicationId);
+
+      const client = algoliasearch(applicationId, apiKey);
+
+      const task = await client.setSettings({
+        indexName,
+        indexSettings: {
+          customRanking: customRanking.map(
+            ({ attribute, direction }) => `${direction}(${attribute})`,
+          ),
+        },
+      });
+
+      await client.waitForTask({ indexName, taskID: task.taskID });
+
+      const currentSettings = await client.getSettings({
+        indexName,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              currentSettings.customRanking != null
+                ? `The current attributes used for custom ranking: ${currentSettings.customRanking.join(", ")}`
+                : "No attributes for faceting found.",
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
Add two new tools related to complex settings: attributes for faceting and custom ranking
Custom ranking needs attribute names and direction, which defaults to descending, like in the dashboard