### PR TITLE
feat(response): handle JSON Lines

### DIFF
--- a/src/tools/registerOpenApi.test.ts
+++ b/src/tools/registerOpenApi.test.ts
@@ -45,9 +45,7 @@ describe("registerOpenApiTools", () => {
 
     server.use(
       http.get("https://appid.algolia.net/1/indexes/indexName/settings", () =>
-        HttpResponse.json({
-          searchableAttributes: ["title"],
-        }),
+        HttpResponse.json({ searchableAttributes: ["title"] }),
       ),
     );
     const result = await toolCallback({
@@ -65,7 +63,7 @@ describe("registerOpenApiTools", () => {
     });
   });
 
-  it("should generate a getSettings tool responding with JSONL", async () => {
+  it("should work with jsonl responses", async () => {
     const toolFilter: ToolFilter = {
       allowedTools: new Set(["getSettings"]),
     };
@@ -95,12 +93,11 @@ describe("registerOpenApiTools", () => {
 
     const toolCallback = serverMock.tool.mock.calls[0][3];
 
+    const jsonlResponse = `{ "searchableAttributes": ["title"] }
+{ "searchableAttributes": ["genre"] }`;
     server.use(
       http.get("https://appid.algolia.net/1/indexes/indexName/settings", () =>
-        HttpResponse.text(`
-          { "searchableAttributes": ["title"] }
-          { "searchableAttributes": ["genre"] }
-          `),
+        HttpResponse.text(jsonlResponse),
       ),
     );
     const result = await toolCallback({
@@ -111,7 +108,7 @@ describe("registerOpenApiTools", () => {
     expect(result).toEqual({
       content: [
         {
-          text: '[{"searchableAttributes":["title"]},{"searchableAttributes":["genre"]}]',
+          text: jsonlResponse,
           type: "text",
         },
       ],

--- a/src/tools/registerOpenApi.ts
+++ b/src/tools/registerOpenApi.ts
@@ -5,6 +5,7 @@ import { jsonSchemaToZod } from "../helpers.ts";
 import { isToolAllowed, type ToolFilter } from "../toolFilters.ts";
 import type { Methods, OpenApiSpec, Operation, SecurityScheme } from "../openApi.ts";
 import { CONFIG } from "../config.ts";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 export type RequestMiddleware = (opts: {
   request: Request;
@@ -92,7 +93,6 @@ export async function registerOpenApiTools({
           ...buildUrlParameters(openApiSpec.servers),
           ...buildParametersZodSchema(operation),
         },
-        // @ts-expect-error - the types are hard to satisfy when building tools dynamically. Just trust me bro.
         toolCallback,
       );
     }
@@ -121,7 +121,7 @@ function buildToolCallback({
   dashboardApi,
 }: ToolCallbackBuildOptions) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return async (params: Record<string, any>) => {
+  return async (params: Record<string, any>): Promise<CallToolResult> => {
     const { requestBody } = params;
 
     if (method === "get" && requestBody) {
@@ -194,34 +194,12 @@ function buildToolCallback({
     }
 
     const response = await fetch(request);
-    const data = await decodeResponse(response);
+    const text = await response.text();
 
     return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify(data),
-        },
-      ],
+      content: [{ type: "text", text }],
     };
   };
-}
-
-async function decodeResponse(response: Response) {
-  const text = await response.text();
-
-  try {
-    // Try to parse as regular JSON
-    return JSON.parse(text);
-  } catch {
-    // Fallback: try to parse as JSONLines
-    const lines = text
-      .split("\n")
-      .filter((line) => line.trim() !== "")
-      .map((line) => JSON.parse(line));
-
-    return lines;
-  }
 }
 
 function isJsonString(json: unknown): json is string {

--- a/src/tools/registerOpenApi.ts
+++ b/src/tools/registerOpenApi.ts
@@ -194,7 +194,7 @@ function buildToolCallback({
     }
 
     const response = await fetch(request);
-    const data = await response.json();
+    const data = await decodeResponse(response);
 
     return {
       content: [
@@ -205,6 +205,23 @@ function buildToolCallback({
       ],
     };
   };
+}
+
+async function decodeResponse(response: Response) {
+  const text = await response.text();
+
+  try {
+    // Try to parse as regular JSON
+    return JSON.parse(text);
+  } catch {
+    // Fallback: try to parse as JSONLines
+    const lines = text
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => JSON.parse(line));
+
+    return lines;
+  }
 }
 
 function isJsonString(json: unknown): json is string {


### PR DESCRIPTION
## What
A tentative way to parse both JSON and JSON lines API responses and send back a JSON string as the tool's response.

## Why
Query Suggestions' API endpoint `/1/logs` responds with the logs in a JSON lines format, which will throw errors when calling `response.json()` (or `JSON.parse`). 
Seeing as how valuable it could be to troubleshoot a Query Suggestions build with an LLM ("Why is {query} missing in my suggestions index" -> "It has less than 2 results"), I'm proposing this way of decoding all responses.

## Tests

- [x] Tested with debugger
- [x] Added test
- [ ] Test with LLM client (not done because out of credits)