### PR TITLE
feat: add annotations hints to open api generated tools

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,14 @@ export default defineConfig([
       rules: {
         "no-param-reassign": ["error"],
         "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            argsIgnorePattern: "^_",
+            ignoreRestSiblings: true,
+            varsIgnorePattern: "^_",
+          },
+        ],
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.9.0",
+        "@modelcontextprotocol/sdk": "^1.11.0",
         "algoliasearch": "^5.23.4",
         "commander": "^13.1.0",
         "open": "^10.1.0",
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
-      "integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.0.tgz",
+      "integrity": "sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.11.0",
     "algoliasearch": "^5.23.4",
     "commander": "^13.1.0",
     "open": "^10.1.0",

--- a/src/openApi.ts
+++ b/src/openApi.ts
@@ -14,6 +14,7 @@ export type Methods = "get" | "post" | "put" | "delete";
 
 export type Operation = {
   "x-helper"?: boolean;
+  "x-use-read-transporter"?: boolean;
   operationId: string;
   summary?: string;
   description?: string;

--- a/src/tools/registerGetApplications.ts
+++ b/src/tools/registerGetApplications.ts
@@ -5,7 +5,7 @@ export const operationId = "getApplications";
 export const description = "Gets a paginated list of Algolia applications for the current user";
 
 export function registerGetApplications(server: McpServer, dashboardApi: DashboardApi) {
-  server.tool(operationId, description, async () => {
+  server.tool(operationId, description, { readOnlyHint: true }, async () => {
     const applications = await dashboardApi.getApplications();
 
     return {

--- a/src/tools/registerGetUserInfo.ts
+++ b/src/tools/registerGetUserInfo.ts
@@ -5,7 +5,7 @@ export const operationId = "getUserInfo";
 export const description = "Get information about the user in the Algolia system";
 
 export function registerGetUserInfo(server: McpServer, dashboardApi: DashboardApi) {
-  server.tool(operationId, description, async () => {
+  server.tool(operationId, description, { readOnlyHint: true }, async () => {
     const user = await dashboardApi.getUser();
 
     return {

--- a/src/tools/registerOpenApi.test.ts
+++ b/src/tools/registerOpenApi.test.ts
@@ -5,6 +5,10 @@ import type { DashboardApi } from "../DashboardApi.ts";
 import { SearchSpec } from "../openApi.ts";
 import { registerOpenApiTools } from "./registerOpenApi.ts";
 import { setupServer } from "msw/node";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
 
 const server = setupServer();
 
@@ -39,9 +43,11 @@ describe("registerOpenApiTools", () => {
         indexName: expect.anything(),
       }),
       expect.anything(),
+      expect.anything(),
     );
 
-    const toolCallback = serverMock.tool.mock.calls[0][3];
+    const [_name, _description, _schema, _annotations, toolCallback] =
+      serverMock.tool.mock.calls[0];
 
     server.use(
       http.get("https://appid.algolia.net/1/indexes/indexName/settings", () =>
@@ -80,18 +86,8 @@ describe("registerOpenApiTools", () => {
       toolFilter,
     });
 
-    expect(serverMock.tool).toHaveBeenCalledTimes(1);
-    expect(serverMock.tool).toHaveBeenCalledWith(
-      "getSettings",
-      "Retrieve index settings",
-      expect.objectContaining({
-        applicationId: expect.anything(),
-        indexName: expect.anything(),
-      }),
-      expect.anything(),
-    );
-
-    const toolCallback = serverMock.tool.mock.calls[0][3];
+    const [_name, _description, _schema, _annotations, toolCallback] =
+      serverMock.tool.mock.calls[0];
 
     const jsonlResponse = `{ "searchableAttributes": ["title"] }
 { "searchableAttributes": ["genre"] }`;
@@ -113,5 +109,40 @@ describe("registerOpenApiTools", () => {
         },
       ],
     });
+  });
+
+  it("should generate annotations hints", async () => {
+    const server = new McpServer({ name: "algolia", version: "1.0.0" });
+    const client = new Client({ name: "test client", version: "1.0.0" });
+
+    registerOpenApiTools({
+      server,
+      dashboardApi: {} as DashboardApi,
+      openApiSpec: SearchSpec,
+      toolFilter: {
+        allowedTools: new Set(["getSettings", "setSettings", "browse"]),
+      },
+    });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const listResult = await client.request({ method: "tools/list" }, ListToolsResultSchema);
+
+    expect(listResult.tools).toHaveLength(3);
+
+    const [browseTool, getSettingsTool, setSettingsTool] = listResult.tools;
+
+    // Browse tool uses the http post method, but has the x-use-read-transporter set to true
+    expect(browseTool.name).toBe("browse");
+    expect(browseTool.annotations).toEqual({ destructiveHint: false, readOnlyHint: true });
+
+    // get settings uses the http get method
+    expect(getSettingsTool.name).toBe("getSettings");
+    expect(getSettingsTool.annotations).toEqual({ destructiveHint: false, readOnlyHint: true });
+
+    // set settings uses the http post method
+    expect(setSettingsTool.name).toBe("setSettings");
+    expect(setSettingsTool.annotations).toEqual({ destructiveHint: true, readOnlyHint: false });
   });
 });

--- a/src/tools/registerOpenApi.ts
+++ b/src/tools/registerOpenApi.ts
@@ -85,6 +85,8 @@ export async function registerOpenApiTools({
         securitySchemes: openApiSpec.components?.securitySchemes ?? {},
       });
 
+      const isReadOnly = Boolean(method === "get" || operation["x-use-read-transporter"]);
+
       server.tool(
         operation.operationId,
         operation.summary || operation.description || "",
@@ -93,6 +95,7 @@ export async function registerOpenApiTools({
           ...buildUrlParameters(openApiSpec.servers),
           ...buildParametersZodSchema(operation),
         },
+        { destructiveHint: !isReadOnly, readOnlyHint: isReadOnly },
         toolCallback,
       );
     }

--- a/src/tools/registerSetAttributesForFaceting.ts
+++ b/src/tools/registerSetAttributesForFaceting.ts
@@ -19,7 +19,9 @@ const attributesForFacetingSchema = {
     .enum(["append", "replace"])
     .optional()
     .default("append")
-    .describe("If `append`, the attributes will be added to the existing ones (default strategy to avoid overwriting). If `replace`, the existing attributes will be replaced."),
+    .describe(
+      "If `append`, the attributes will be added to the existing ones (default strategy to avoid overwriting). If `replace`, the existing attributes will be replaced.",
+    ),
 };
 
 export function registerSetAttributesForFaceting(server: McpServer, dashboardApi: DashboardApi) {
@@ -27,12 +29,13 @@ export function registerSetAttributesForFaceting(server: McpServer, dashboardApi
     operationId,
     description,
     attributesForFacetingSchema,
+    { destructiveHint: true },
     async ({ applicationId, indexName, attributesForFaceting, strategy }) => {
       const apiKey = await dashboardApi.getApiKey(applicationId);
       const client = algoliasearch(applicationId, apiKey);
 
       let newAttributes: string[] = [];
-      if (strategy === 'append') {
+      if (strategy === "append") {
         const currentSettings = await client.getSettings({
           indexName,
         });

--- a/src/tools/registerSetCustomRanking.ts
+++ b/src/tools/registerSetCustomRanking.ts
@@ -28,7 +28,9 @@ const setCustomRankingSchema = {
     .enum(["append", "replace"])
     .optional()
     .default("append")
-    .describe("If `append`, the attributes will be added to the existing ones (default strategy to avoid overwriting). If `replace`, the existing attributes will be replaced."),
+    .describe(
+      "If `append`, the attributes will be added to the existing ones (default strategy to avoid overwriting). If `replace`, the existing attributes will be replaced.",
+    ),
 };
 
 export function registerSetCustomRanking(server: McpServer, dashboardApi: DashboardApi) {
@@ -36,6 +38,7 @@ export function registerSetCustomRanking(server: McpServer, dashboardApi: Dashbo
     operationId,
     description,
     setCustomRankingSchema,
+    { destructiveHint: true },
     async ({ applicationId, indexName, customRanking, strategy }) => {
       const apiKey = await dashboardApi.getApiKey(applicationId);
       const client = algoliasearch(applicationId, apiKey);


### PR DESCRIPTION
## 🤔 What
- **feat:** add annotations hints to open api generated tools

## 🤷 Why
Annotations shipped in the SDK in https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/1.11.0
They could help MCP Clients offer a better experience by only confirming destructive operations

## 🔍 How
- Update sdk to `1.11.0`
- Mark Open API generated tools as read only if they the method is `get` or if `x-use-read-transporter` is set to true
- Updated manually defined tools accordingly

## 🧪 Testing
Added corresponding tests ✅ 
